### PR TITLE
Switch to packageManager, avoid Corepack prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ CodeSandbox uses `zsh` as the default shell (not configurable as of May 2024), a
 
 `.codesandbox/Dockerfile`
 
-```dockerfile
+````dockerfile
 FROM node:lts-alpine
 
 # 1. zsh is default shell on CodeSandbox - without it,
@@ -53,16 +53,18 @@ FROM node:lts-alpine
 # "/root/.oh-my-zsh/tools/check_for_upgrade.sh:31: command not found: git"
 # ```
 RUN apk update && apk add --no-cache zsh git
-```
+````
 
 ## Use pnpm
 
-By default CodeSandbox uses Yarn v1 as a package manager. To use pnpm in a reproducible way, configure your desired pnpm version in `engines.pnpm` in your `package.json`, enable Corepack in your Dockerfile and add `pnpm install` to your `setupTasks`:
+By default CodeSandbox uses Yarn v1 as a package manager. To use pnpm in a reproducible way, configure your desired pnpm version in `packageManager` in your `package.json`, enable Corepack in your Dockerfile and add `pnpm install` to your `setupTasks`. To avoid Corepack from [prompting questions](https://github.com/nodejs/corepack/blob/main/README.md#:~:text=COREPACK_ENABLE_DOWNLOAD_PROMPT) during `pnpm install`, set `ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in your Dockerfile:
 
 `.codesandbox/Dockerfile`
 
 ```dockerfile
 FROM node:lts-slim
+
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 RUN corepack enable
 ```
@@ -91,8 +93,8 @@ RUN corepack enable
 
 ```json
 {
-  "engines": {
-    "pnpm": "9.1.0"
+  "packageManager": {
+    "pnpm": "pnpm@9.1.1+sha512.14e915759c11f77eac07faba4d019c193ec8637229e62ec99eefb7cf3c3b75c64447882b7c485142451ee3a6b408059cdfb7b7fa0341b975f12d0f7629c71195"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RUN apk update && apk add --no-cache zsh git
 
 ## Use pnpm
 
-By default CodeSandbox uses Yarn v1 as a package manager. To use pnpm in a reproducible way, configure your desired pnpm version in `packageManager` in your `package.json`, enable Corepack and disable Corepack download prompts in your Dockerfile and add `pnpm install` to your `setupTasks`:
+By default CodeSandbox uses Yarn v1 as a package manager. To use pnpm in a reproducible way, configure your desired pnpm version in `packageManager` in your `package.json`, enable Corepack without download prompts in your Dockerfile and add `pnpm install` to your `setupTasks`:
 
 `.codesandbox/Dockerfile`
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ RUN corepack enable
 
 ```json
 {
-  "packageManager": {
-    "pnpm": "pnpm@9.1.1+sha512.14e915759c11f77eac07faba4d019c193ec8637229e62ec99eefb7cf3c3b75c64447882b7c485142451ee3a6b408059cdfb7b7fa0341b975f12d0f7629c71195"
-  }
+  "packageManager": "pnpm@9.1.1+sha512.14e915759c11f77eac07faba4d019c193ec8637229e62ec99eefb7cf3c3b75c64447882b7c485142451ee3a6b408059cdfb7b7fa0341b975f12d0f7629c71195"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,13 +57,21 @@ RUN apk update && apk add --no-cache zsh git
 
 ## Use pnpm
 
-By default CodeSandbox uses Yarn v1 as a package manager. To use pnpm in a reproducible way, configure your desired pnpm version in `packageManager` in your `package.json`, enable Corepack in your Dockerfile and add `pnpm install` to your `setupTasks`. To avoid Corepack from [prompting questions](https://github.com/nodejs/corepack/blob/main/README.md#:~:text=COREPACK_ENABLE_DOWNLOAD_PROMPT) during `pnpm install`, set `ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in your Dockerfile:
+By default CodeSandbox uses Yarn v1 as a package manager. To use pnpm in a reproducible way, configure your desired pnpm version in `packageManager` in your `package.json`, enable Corepack and disable Corepack download prompts in your Dockerfile and add `pnpm install` to your `setupTasks`:
 
 `.codesandbox/Dockerfile`
 
 ```dockerfile
 FROM node:lts-slim
 
+# Avoid Corepack download prompts during `pnpm install`, eg:
+#
+# ```
+# ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-9.1.1.tgz
+# ? Do you want to continue? [Y/n]
+# ```
+#
+# https://github.com/nodejs/corepack/tree/09528a8ea8f2a953b67c9079615eae3394531862#:~:text=COREPACK_ENABLE_DOWNLOAD_PROMPT
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 RUN corepack enable

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ CodeSandbox uses `zsh` as the default shell (not configurable as of May 2024), a
 
 `.codesandbox/Dockerfile`
 
-````dockerfile
+```dockerfile
 FROM node:lts-alpine
 
 # 1. zsh is default shell on CodeSandbox - without it,
@@ -53,7 +53,7 @@ FROM node:lts-alpine
 # "/root/.oh-my-zsh/tools/check_for_upgrade.sh:31: command not found: git"
 # ```
 RUN apk update && apk add --no-cache zsh git
-````
+```
 
 ## Use pnpm
 


### PR DESCRIPTION
- [`corepack@0.26.0`](https://github.com/nodejs/corepack/releases/tag/v0.26.0) adds `"packageManager"` to `package.json` (see example below) after this PR: https://github.com/nodejs/corepack/pull/413/
- Avoid the Corepack download prompt caused by `pnpm install` by setting [`COREPACK_ENABLE_DOWNLOAD_PROMPT=0`](https://github.com/nodejs/corepack/blob/main/README.md#:~:text=COREPACK_ENABLE_DOWNLOAD_PROMPT)

```json
   "packageManager": "pnpm@9.1.1+sha512.14e915759c11f77eac07faba4d019c193ec8637229e62ec99eefb7cf3c3b75c64447882b7c485142451ee3a6b408059cdfb7b7fa0341b975f12d0f7629c71195"
```